### PR TITLE
…so do.

### DIFF
--- a/antioxidant-ci.scm
+++ b/antioxidant-ci.scm
@@ -18,6 +18,7 @@
 (define-module (antioxidant-ci)
   #:use-module ((antioxidant-packages) #:select (vitaminate/auto public-test-package))
   #:use-module ((guix build-system cargo) #:select (cargo-build-system))
+  #:use-module ((guix profiles) #:select (packages->manifest))
   #:use-module ((gnu packages) #:select (fold-packages))
   #:use-module ((rnrs exceptions) #:select (guard))
   #:use-module ((guix packages) #:select (package-build-system package-name))
@@ -41,3 +42,4 @@
   (fold-packages add '() #:select? is-leaf-cargo-rust-package?))
 
 ;; The idea is to build all packages in (all-packages) by the CI infrastructure.
+(packages->manifest (all-packages))


### PR DESCRIPTION
Hi Maxime,

I didn't get Cuirass to build a nekkid list of package objects (if that's even supported), so I wrapped it in a manifest.

If this is merged, I'll switch [the antiox Cuirass job](
https://ci.guix.gnu.org/jobset/antiox) back to your mirror.

* antioxidant-ci.scm: Return a manifest for Cuirass.